### PR TITLE
Adding 404 Page

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,10 @@ app.use(bodyParser.urlencoded({ extended: false }));
 app.use(adminRouter);
 app.use(shopRouter);
 
+app.use((req, res, next) => {
+    res.status(404).send('<h1>Page not found</h1>');
+});
+
 app.listen(3000);
 
 


### PR DESCRIPTION
The system should be able to handle unmatched route gracefully.
When a route does not find a matching route handler middleware it must fallback to middleware function that renders a 404 Page.

Closes #28